### PR TITLE
fix: resolve GitHub Actions test failures

### DIFF
--- a/internal/cli/done.go
+++ b/internal/cli/done.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -361,6 +362,7 @@ func buildPRTitle(tasks []state.Task) string {
 			parts = append(parts, fmt.Sprintf("%d %s tasks", count, cat))
 		}
 	}
+	sort.Strings(parts)
 
 	if len(parts) > 0 {
 		return "Implement " + strings.Join(parts, ", ")

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -467,7 +467,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 	assert.Contains(t, bashCmd, "--dangerously-skip-permissions")
 	assert.Contains(t, bashCmd, "--verbose") // required when using -p with --output-format stream-json
 	assert.Contains(t, bashCmd, "--output-format stream-json")
-	assert.Contains(t, bashCmd, "--max-turns 100")
+	assert.Contains(t, bashCmd, "--max-turns 200")
 
 	// Check budget flag from config.Limits (since ClaudeConfig.MaxBudget is 0)
 	assert.Contains(t, bashCmd, "--max-budget-usd 15.50")


### PR DESCRIPTION
- Update TestBuildClaudeArgs to expect --max-turns 200 (matching
  the new default from f5389cf)
- Sort categories in buildPRTitle for deterministic output, fixing
  the flaky TestBuildPRTitle/fallback_for_no_features test caused
  by non-deterministic Go map iteration order