### PR TITLE
fix(loop): update TUI after syncing state from Sprite

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -230,6 +230,9 @@ func (l *Loop) Run(ctx context.Context) Result {
 			}
 		}
 
+		// Update TUI with freshly synced state
+		l.updateTUIState()
+
 		// Broadcast state to web clients if server is running
 		l.broadcastState(iterResult)
 


### PR DESCRIPTION
The TUI was only updated before each iteration, not after syncing the updated state from Sprite. This meant task completion counts were always one iteration behind - showing stale data from before Claude ran.

Added l.updateTUIState() call after SyncFromSprite() completes to ensure the TUI reflects the freshly synced task state.

Also added tests to verify TUI state updates correctly:
- TestUpdateTUIState: verifies updateTUIState reads from store correctly
- TestTUIStateUpdatedAfterSync: regression test for this bug
- TestTUIStateReflectsProgressDuringLoop: verifies progress over multiple syncs