### PR TITLE
Fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Wisp automates spec-driven development using pure bash loop Ralph in isolated [S
 ## Install
 
 ```bash
-go install github.com/thruflo/wisp@latest
+go install github.com/thruflo/wisp/cmd/wisp@latest
 ```
 
 ## Setup


### PR DESCRIPTION
## Summary
Updated the installation command in the README to reflect the correct import path for the wisp CLI tool.

## Changes
- Updated `go install` command from `github.com/thruflo/wisp@latest` to `github.com/thruflo/wisp/cmd/wisp@latest`

## Details
The CLI binary is located in the `cmd/wisp` subdirectory of the repository, so the installation command must specify the full path to the executable. This ensures users can successfully install wisp using the documented installation method.